### PR TITLE
Just ship the exporter binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
+FROM golang:1.14.0 as build
+
+COPY . /src
+RUN set -ex \
+    && cd /src \
+    && CGO_ENABLED=0 go build -o /bin/prometheus-exporter
+
 FROM alpine:latest
 MAINTAINER CMogilko <cmogilko@gmail.com>
 
-RUN apk add --update -t build-deps go git make
+COPY --from=build /bin/prometheus-exporter /bin/prometheus-exporter
 
-COPY . /src
-
-RUN cd /src && go build -o /bin/prometheus-exporter
-RUN rm -rf /src
-
-RUN apk del --purge build-deps go git make
-
+USER nobody
 EXPOSE     9055
 ENTRYPOINT [ "/bin/prometheus-exporter" ]


### PR DESCRIPTION
**Reason for the change**
Every layer was is still part of the image, by using multiple `RUN`, these create a unique layer that is packaged with the image, increasing the size of the image.

**Description**
Use a golang compiler, to produce only a self contained binary, and then distribute that binary running as nobody on alpine.

**Code examples**
Using: wagoodman/dive:latest, this container breaks down the container layer usage.

Current Dockerfile:

```
Total Image size: 591 MB
Potential wasted space: 42 MB
Image efficiency score: 95 %
```

My Change:
```
Total Image size: 22 MB
Potential wasted space: 0 B
Image efficiency score: 100 %
```

**Checklist**
- [X] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
